### PR TITLE
Potential Auth models

### DIFF
--- a/esgf_playground_utils/models/auth.py
+++ b/esgf_playground_utils/models/auth.py
@@ -1,0 +1,48 @@
+"""
+Models relating to Authorisation for the ESGF Next Gen Core Architecture.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class Node(BaseModel):
+    """
+    Model describing Node auth info of a ESGF publisher.
+    """
+
+    id: str
+    role: Literal[
+        "CREATE",
+        "UPDATE",
+        "DELETE",
+        "REPLICATE",
+        "REVOKE",
+    ]
+
+
+class Project(BaseModel):
+    """
+    Model describing Project auth info of a ESGF publisher.
+    """
+
+    id: str
+    role: Literal[
+        "CREATE",
+        "UPDATE",
+        "DELETE",
+        "REPLICATE",
+        "REVOKE",
+    ]
+
+
+class ESGFAuth(BaseModel):
+    """
+    Model describing Authentication information of a ESGF publisher.
+    """
+
+    sub: str
+    iss: str
+    nodes: list[Node]
+    projects: list[Project]


### PR DESCRIPTION
My understanding of the transaction api's authroisation code is:
- The [authorizer](https://github.com/esgf2-us/stac-transaction-api/blob/west-playground/src/authorizer.py) collects information about the user and adds it to the request state.
- The client then calls its [authorize method](https://github.com/esgf2-us/stac-transaction-api/blob/west-playground/src/client.py#L30-L96) which check the incoming payload against the generated authorisation state.

This pull request adds a pydantic model for the return of the [authorizer](https://github.com/esgf2-us/stac-transaction-api/blob/west-playground/src/authorizer.py). If the East and West authorizer middleware returns the same model it would allow us to use the same [authorize method](https://github.com/esgf2-us/stac-transaction-api/blob/west-playground/src/client.py#L30-L96) in the client.

Any objections to having a model for the return of the [authorizer](https://github.com/esgf2-us/stac-transaction-api/blob/west-playground/src/authorizer.py)? Or to the structure or content of the model?